### PR TITLE
Fix the wrong price for gpt3.5

### DIFF
--- a/models.py
+++ b/models.py
@@ -41,5 +41,5 @@ def gpt_usage(backend="gpt-4"):
     if backend == "gpt-4":
         cost = completion_tokens / 1000 * 0.06 + prompt_tokens / 1000 * 0.03
     elif backend == "gpt-3.5-turbo":
-        cost = (completion_tokens + prompt_tokens) / 1000 * 0.0002
+        cost = completion_tokens / 1000 * 0.002 + prompt_tokens / 1000 * 0.0015
     return {"completion_tokens": completion_tokens, "prompt_tokens": prompt_tokens, "cost": cost}


### PR DESCRIPTION
I tried ToT using the gpt-3.5-turbo model, and the final cost was 10 times smaller than what the openai website showed. Therefore, I modified file models.py according to Openai's official price (https://openai.com/pricing).